### PR TITLE
Add "What to read next" section to blog article (suggested articles)

### DIFF
--- a/assets/styles/_container.scss
+++ b/assets/styles/_container.scss
@@ -10,5 +10,6 @@
 
   &--thinner {
     max-width: 50rem;
+    margin-inline: auto;
   }
 }

--- a/components/ArticleList.vue
+++ b/components/ArticleList.vue
@@ -87,7 +87,7 @@ const props = defineProps({
   }
 })
 
-const { data: blog } = await useAsyncData(`article-list-${$route.params.slug}`, (ctx) => { return ctx!.$contentful.getEntries<{ fields: Omit<ContentfulEntries.Article, 'body'>, contentTypeId: 'article' }>({ content_type: 'article', limit: 1000, order: ['-fields.publishDate'], select: ['fields.title', 'fields.description', 'fields.image', 'fields.tags', 'fields.publishDate', 'fields.slug'] })})
+const { data: blog } = await useAsyncData(`article-list-${$route.params.slug}`, (ctx) => { return ctx!.$contentful.getEntries<{ fields: Pick<ContentfulEntries.Article, 'title'|'description'|'image'|'tags'|'publishDate'|'slug'>, contentTypeId: 'article' }>({ content_type: 'article', limit: 1000, order: ['-fields.publishDate'], select: ['fields.title', 'fields.description', 'fields.image', 'fields.tags', 'fields.publishDate', 'fields.slug'] })})
 const list = formatCMSVariables(blog.value!.items)
 
 const displayedList = ref<typeof list>([]);

--- a/components/ArticleList.vue
+++ b/components/ArticleList.vue
@@ -1,9 +1,9 @@
 <template>
-  <div>
-    <div v-if="showFilter" :class="props.container === 'thinner' ? 'container--thinner' : 'container'">
+  <div class="container">
+    <div v-if="showFilter">
       <ComboboxInput id="filter" label="Filters" :multiselectable="true" :value="routeFilters" :options="filterOptions" class="filter" @selected-options="updateFilters($event)" @focus="scrollComboboxToTop()" />
     </div>
-    <ul class="posts" :class="props.container === 'thinner' ? 'container--thinner' : 'container'">
+    <ul class="posts">
       <li v-for="(item, index) in displayedList" v-show="articleMatchesFilter(item)" :key="item.sys.id">
         <nuxt-link :to="`/blog/${new Date(item.fields.publishDate).getFullYear()}/${item.fields.slug}`" class="post">
           <article class="post__article">
@@ -72,10 +72,6 @@ const props = defineProps({
   showFilter: {
     type: Boolean,
     default: false
-  },
-  container: {
-    type: String as PropType<'default'|'thinner'>,
-    default: 'default'
   },
   suggested: {
     type: Object as PropType<Suggested>,
@@ -185,7 +181,7 @@ $postWidth: 26.5rem;
   flex-wrap: wrap;
   gap: 3rem 0.5rem;
 
-  &.container--thinner > li {
+  .container--thinner & > li {
     width: 23rem;
   }
 

--- a/components/ArticleList.vue
+++ b/components/ArticleList.vue
@@ -1,16 +1,17 @@
 <template>
   <div>
-    <div v-if="showFilter" class="container">
+    <div v-if="showFilter" :class="props.container === 'thinner' ? 'container--thinner' : 'container'">
       <ComboboxInput id="filter" label="Filters" :multiselectable="true" :value="routeFilters" :options="filterOptions" class="filter" @selected-options="updateFilters($event)" @focus="scrollComboboxToTop()" />
     </div>
-    <ul class="posts container">
-      <li v-for="(item, index) in list" v-show="articleMatchesFilter(item) && index < props.limit" :key="item.sys.id">
+    <ul class="posts" :class="props.container === 'thinner' ? 'container--thinner' : 'container'">
+      <li v-for="(item, index) in displayedList" v-show="articleMatchesFilter(item)" :key="item.sys.id">
         <nuxt-link :to="`/blog/${new Date(item.fields.publishDate).getFullYear()}/${item.fields.slug}`" class="post">
           <article class="post__article">
+            <p v-if="props.suggested.titles.includes(item.fields.title)" class="post__banner">Suggested</p>
             <nuxt-picture class="post__img" provider="contentful" :src="item.fields.image!.fields.file!.url" :alt="item.fields.image!.fields.description" width="424" height="223" sizes="4kdesktop:424px" loading="lazy" :preload="index <= props.preloadArticleImages" />
             <div class="post__details">
               <ul class="post__tags">
-                <li v-for="tag in item.fields.tags" :key="tag" class="tag">
+                <li v-for="tag in item.fields.tags" :key="tag" class="tag" :class="{ 'tag--bold': props.suggested.tags.includes(tag) }">
                   {{ tag }}
                 </li>
               </ul>
@@ -33,11 +34,18 @@
 </template>
 
 <script lang="ts" setup>
+import { type PropType } from 'vue';
 import dayjs from 'dayjs'
 import type { LastArrayElement } from 'type-fest';
 import type { ContentfulEntries } from '@/types/CMS/Entries'
 import { formatCMSVariables } from '@/utilities/cmsVariables';
 import type { ComboboxOption } from '@/types/components/ComboboxInput'
+
+interface Suggested {
+  current: string;
+  titles: string[];
+  tags: string[];
+}
 
 const ComboboxInput = defineAsyncComponent(() => import('./ComboboxInput.vue'))
 
@@ -49,7 +57,7 @@ const filters = ref<string[]>([])
 const props = defineProps({
   limit: {
     type: Number,
-    default: 1000,
+    default: undefined,
     validator(value: number): boolean {
       return value >= 0 && value <= 1000
     }
@@ -64,11 +72,69 @@ const props = defineProps({
   showFilter: {
     type: Boolean,
     default: false
+  },
+  container: {
+    type: String as PropType<'default'|'thinner'>,
+    default: 'default'
+  },
+  suggested: {
+    type: Object as PropType<Suggested>,
+    default: {
+      current: '',
+      titles: [],
+      tags: []
+    } satisfies Suggested
   }
 })
 
 const { data: blog } = await useAsyncData(`article-list-${$route.params.slug}`, (ctx) => { return ctx!.$contentful.getEntries<{ fields: Omit<ContentfulEntries.Article, 'body'>, contentTypeId: 'article' }>({ content_type: 'article', limit: 1000, order: ['-fields.publishDate'], select: ['fields.title', 'fields.description', 'fields.image', 'fields.tags', 'fields.publishDate', 'fields.slug'] })})
 const list = formatCMSVariables(blog.value!.items)
+
+const displayedList = ref<typeof list>([]);
+
+if (props.suggested.current) {
+  // Remove current article from the suggested article list
+  list.splice(list.indexOf(list.filter(article => article.fields.title === props.suggested.current)[0]), 1)
+
+  if (props.suggested.titles.length > 0) {
+    const suggestedArticles = list.filter(x => props.suggested.titles.includes(x.fields.title))
+    for (const article of suggestedArticles) {
+      if (!displayedList.value.includes(article)) {
+        displayedList.value.push(article)
+      }
+    }
+  }
+
+  if (!props.limit || displayedList.value.length < props.limit) {
+    for (const tag of props.suggested.tags) {
+      const similarArticles = list.filter(x => x.fields.tags.includes(tag))
+      for (const article of similarArticles) {
+        if (!displayedList.value.includes(article)) {
+          displayedList.value.push(article)
+        }
+      }
+    }
+  }
+
+  if (!props.limit || displayedList.value.length < props.limit) {
+    for (const article of list) {
+      if (!displayedList.value.includes(article)) {
+        displayedList.value.push(article)
+      }
+    }
+  }
+}
+else {
+  displayedList.value = [...list] // Create a clone of the array
+}
+
+if (props.limit && props.limit <= displayedList.value.length) {
+  displayedList.value.length = props.limit;
+}
+
+/***************/
+/** Filtering **/
+/***************/
 
 const tags = [...new Set(list.map(x => x.fields.tags.join(',')).join(',').split(','))].filter(Boolean).sort()
 const years = [...new Set(list.map(x => `${new Date(x.fields.publishDate).getFullYear()}`))].filter(Boolean)
@@ -119,6 +185,10 @@ $postWidth: 26.5rem;
   flex-wrap: wrap;
   gap: 3rem 0.5rem;
 
+  &.container--thinner > li {
+    width: 23rem;
+  }
+
   > li {
     width: $postWidth;
     max-width: 100%;
@@ -126,6 +196,7 @@ $postWidth: 26.5rem;
 }
 
 .post {
+  position: relative;
   display: block;
   overflow: hidden;
   background-color: var(--color-bg);
@@ -138,6 +209,22 @@ $postWidth: 26.5rem;
 
   &:hover {
     background-color: var(--color-fg1);
+  }
+
+  &__banner {
+    position: absolute;
+    background-color: var(--color-accent);
+    color: #27242b;
+    transform-origin: center;
+    transform: rotate(-45deg);
+    margin: 0;
+    padding: 0.25rem 0;
+    top: 1.75rem;
+    left: -2.75rem;
+    font-weight: 700;
+    text-align: center;
+    min-width: 11.25rem;
+    max-width: 11.25rem;
   }
 
   &__article {
@@ -197,5 +284,9 @@ $postWidth: 26.5rem;
 
 .tag {
   color: var(--color-accent);
+
+  &--bold {
+    font-weight: 700;
+  }
 }
 </style>

--- a/pages/blog/[year]/[slug].vue
+++ b/pages/blog/[year]/[slug].vue
@@ -67,7 +67,11 @@ const $route = useRoute()
 const config = useRuntimeConfig()
 
 const articleEntries = await useAsyncData(`article-${$route.params.slug}`, (ctx) => { return ctx!.$contentful.getEntries<{ fields: ContentfulEntries.Article, contentTypeId: 'article' }>({ content_type: 'article', limit: 1, "fields.slug": $route.params.slug as string })})
-const article = formatCMSVariables(articleEntries.data.value!.items[0])
+const article = articleEntries.data.value!.items[0]
+// No need for format the whole of `article`, this may have undesired outcomes such as infinite looping if 2 articles are suggestions of each other
+article.fields.body = formatCMSVariables(article.fields.body)
+article.fields.description = formatCMSVariables(article.fields.description)
+article.fields.image = formatCMSVariables(article.fields.image)
 
 const blogDetailsEntries = await useAsyncData((ctx) => { return ctx!.$contentful.getEntries<{ fields: Pick<ContentfulEntries.BlogDetails, 'articleDisclaimer'>, contentTypeId: 'blogDetails' }>({ content_type: 'blogDetails', limit: 1, select: ['fields.articleDisclaimer'] })})
 const blogDetails = blogDetailsEntries.data.value!.items[0]

--- a/pages/blog/[year]/[slug].vue
+++ b/pages/blog/[year]/[slug].vue
@@ -1,43 +1,57 @@
 <template>
-  <article class="article container container--thinner">
-    <header>
-      <h1 class="article__title">{{ article.fields.title }}</h1>
-    </header>
-    <nuxt-picture class="article__img" provider="contentful" :src="article.fields.image!.fields.file!.url" :alt="article.fields.image!.fields.description" width="768" height="403" sizes="4kdesktop:768px" preload />
-    <ul class="article__tags">
-      <li v-for="tag in article.fields.tags" :key="tag" class="tag">
-        <nuxt-link :to="{ path: '/blog', query: { filters: tag.toLowerCase() } }">{{ tag }}</nuxt-link>
-      </li>
-    </ul>
-    <p class="article__date">
-      <strong>Published: </strong>
-      <time :datetime="dayjs(new Date(article.fields.publishDate)).format('YYYY-MM-DD')" :title="dayjs(new Date(article.fields.publishDate)).format('dddd D MMMM YYYY')">
-        {{ dayjs(new Date(article.fields.publishDate)).format('MMMM D, YYYY') }}
-      </time>
-    </p>
-    <div class="rich-text article__content" v-html="parseRichText(article.fields.body, { $img })" />
-    <div v-if="blogDetails.fields.articleDisclaimer" class="article__disclaimer" v-html="parseRichText(blogDetails.fields.articleDisclaimer)" />
-    <ul class="article__share">
-      <li>
-        <a :href="`https://twitter.com/intent/tweet?text=${article.fields.title} by Jack Domleo&url=${config.public.BASE_URL}${$route.path}`" rel="nofollow noopener" target="_blank" data-cooltipz-dir="top" aria-label="Share on Twitter">
-          <nuxt-icon name="twitter" />
-          <span class="sr-only">Share on Twitter</span>
-        </a>
-      </li>
-      <li>
-        <a :href="`https://www.linkedin.com/shareArticle?mini=true&url=${config.public.BASE_URL}${$route.path}&title=${article.fields.title}&summary=${article.fields.title} by Jack Domleo&source=${config.public.BASE_URL}${$route.path}`" rel="nofollow noopener" target="_blank" data-cooltipz-dir="top" aria-label="Share on LinkedIn">
-          <nuxt-icon name="linkedin" />
-          <span class="sr-only">Share on LinkedIn</span>
-        </a>
-      </li>
-      <li>
-        <button data-cooltipz-dir="top" aria-label="Copy link" @click="copyLink()">
-          <nuxt-icon name="link" />
-          <span class="sr-only">Copy link</span>
-        </button>
-      </li>
-    </ul>
-  </article>
+  <div class="article container container--thinner">
+    <article>
+      <header>
+        <h1 class="article__title">{{ article.fields.title }}</h1>
+      </header>
+      <nuxt-picture class="article__img" provider="contentful" :src="article.fields.image!.fields.file!.url" :alt="article.fields.image!.fields.description" width="768" height="403" sizes="4kdesktop:768px" preload />
+      <ul class="article__tags">
+        <li v-for="tag in article.fields.tags" :key="tag" class="tag">
+          <nuxt-link :to="{ path: '/blog', query: { filters: tag.toLowerCase() } }">{{ tag }}</nuxt-link>
+        </li>
+      </ul>
+      <p class="article__date">
+        <strong>Published: </strong>
+        <time :datetime="dayjs(new Date(article.fields.publishDate)).format('YYYY-MM-DD')" :title="dayjs(new Date(article.fields.publishDate)).format('dddd D MMMM YYYY')">
+          {{ dayjs(new Date(article.fields.publishDate)).format('MMMM D, YYYY') }}
+        </time>
+      </p>
+      <div class="rich-text article__content" v-html="parseRichText(article.fields.body, { $img })" />
+      <div v-if="blogDetails.fields.articleDisclaimer" class="article__disclaimer" v-html="parseRichText(blogDetails.fields.articleDisclaimer)" />
+      <ul class="article__share">
+        <li>
+          <a :href="`https://twitter.com/intent/tweet?text=${article.fields.title} by Jack Domleo&url=${config.public.BASE_URL}${$route.path}`" rel="nofollow noopener" target="_blank" data-cooltipz-dir="top" aria-label="Share on Twitter">
+            <nuxt-icon name="twitter" />
+            <span class="sr-only">Share on Twitter</span>
+          </a>
+        </li>
+        <li>
+          <a :href="`https://www.linkedin.com/shareArticle?mini=true&url=${config.public.BASE_URL}${$route.path}&title=${article.fields.title}&summary=${article.fields.title} by Jack Domleo&source=${config.public.BASE_URL}${$route.path}`" rel="nofollow noopener" target="_blank" data-cooltipz-dir="top" aria-label="Share on LinkedIn">
+            <nuxt-icon name="linkedin" />
+            <span class="sr-only">Share on LinkedIn</span>
+          </a>
+        </li>
+        <li>
+          <button data-cooltipz-dir="top" aria-label="Copy link" @click="copyLink()">
+            <nuxt-icon name="link" />
+            <span class="sr-only">Copy link</span>
+          </button>
+        </li>
+      </ul>
+    </article>
+
+    <div class="article__suggested">
+      <h2>What to read next</h2>
+      <ArticleList
+  :limit="2" container="thinner" :suggested="{
+        current: article.fields.title,
+        titles: article.fields.suggestedArticles?.map(x => x?.fields.title || '').filter(Boolean) || [],
+        tags: article.fields.tags || []
+      }
+        "
+      />
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -179,6 +193,14 @@ useHead({
       cursor: pointer;
       display: grid;
       place-items: center;
+    }
+  }
+
+  &__suggested {
+    margin-top: 4rem;
+
+    h2 {
+      font-size: var(--text-subtitle);
     }
   }
 }

--- a/pages/blog/[year]/[slug].vue
+++ b/pages/blog/[year]/[slug].vue
@@ -43,12 +43,13 @@
     <div class="article__suggested">
       <h2>What to read next</h2>
       <ArticleList
-  :limit="2" container="thinner" :suggested="{
-        current: article.fields.title,
-        titles: article.fields.suggestedArticles?.map(x => x?.fields.title || '').filter(Boolean) || [],
-        tags: article.fields.tags || []
-      }
-        "
+        class="container--thinner"
+        :limit="2"
+        :suggested="{
+          current: article.fields.title,
+          titles: article.fields.suggestedArticles?.map(x => x?.fields.title || '').filter(Boolean) || [],
+          tags: article.fields.tags || []
+        }"
       />
     </div>
   </div>

--- a/types/CMS/Entries/Article.d.ts
+++ b/types/CMS/Entries/Article.d.ts
@@ -8,4 +8,5 @@ export interface Article {
   publishDate: EntryFieldTypes.Date;
   tags: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
   body: EntryFieldTypes.RichText;
+  suggestedArticles: EntryFieldTypes.Array<EntryFieldTypes.EntryLink<{ contentTypeId: 'article', fields: Article }>>;
 }


### PR DESCRIPTION
- Add `suggestedArticles` to `"article"` content type to show suggested articles at the end of an article
- If no articles are suggested or number of suggested articles does not meet limit, the remaining space will be filled by:
  - Latest articles with same tags
  - Generic latest articles